### PR TITLE
Add inflection to airing episode view

### DIFF
--- a/AniHyou/Screens/MediaList/Views/MediaListItemStandardView.swift
+++ b/AniHyou/Screens/MediaList/Views/MediaListItemStandardView.swift
@@ -43,7 +43,7 @@ struct AiringScheduleItemText: View {
     var body: some View {
         let airing = item!.media!.nextAiringEpisode!
         let isBehind = item?.progress ?? 0 < airing.episode - 1
-        Text(isBehind ? "\((airing.episode - 1) - (item?.progress ?? 0)) episodes behind" : "Ep \(airing.episode) airing in \(airing.timeUntilAiring.secondsToLegibleText())")
+        Text(isBehind ? "^[\((airing.episode - 1) - (item?.progress ?? 0)) episodes](inflect: true) behind" : "Ep \(airing.episode) airing in \(airing.timeUntilAiring.secondsToLegibleText())")
             .foregroundColor(isBehind ? .accentColor : .gray)
             .font(.subheadline)
             .lineLimit(1)


### PR DESCRIPTION
Added inflection (i.e. "1 episode behind", "2 episodes behind"...) to currently airing items on the ongoing list using automatic grammar agreement. The official AniList web client has similar feature.